### PR TITLE
PromptをPureに変更

### DIFF
--- a/config/nvim/init.vim
+++ b/config/nvim/init.vim
@@ -17,13 +17,6 @@ Plug 'altercation/vim-colors-solarized'
 
 call plug#end()
 
-" Python settings
-"let g:loaded_python_provider = 0
-"let g:python_host_prog = ''
-"if isdirectory(expand($ASDF_DIR))
-"    let g:python3_host_prog = $ASDF_DIR . '/shims/python'
-"endif
-
 syntax enable
 
 " options

--- a/config/zsh/01_zinit.zsh
+++ b/config/zsh/01_zinit.zsh
@@ -11,6 +11,9 @@ zinit light zdharma/fast-syntax-highlighting
 zinit ice from"gh-r" as"program"
 zinit load "junegunn/fzf-bin"
 
+zinit ice compile'(pure|async).zsh' pick'async.zsh' src'pure.zsh'
+zinit light sindresorhus/pure
+
 zinit ice pick"bin/op-tool" as"program"
 zinit light m1yam0t0/op-tool
 

--- a/config/zsh/07_prompt.zsh
+++ b/config/zsh/07_prompt.zsh
@@ -1,43 +1,7 @@
 #-----------------------------------------------------------
-# Variables
-#-----------------------------------------------------------
-# color
-BLUE=$'\e[38;5;33m'
-GREEN=$'\e[38;5;64m'
-YELLOW=$'\e[38;5;136m'
-RED=$'\e[38;5;160m'
-RESET=$'\e[0m'
-
-#-----------------------------------------------------------
-# Options
-#-----------------------------------------------------------
-# enable settings
-setopt prompt_subst
-autoload -Uz vcs_info
-
-# vcs_info
-zstyle ":vcs_info:*" enable git
-zstyle ':vcs_info:git:*' check-for-changes true
-zstyle ':vcs_info:git:*' stagedstr "${YELLOW}!"
-zstyle ':vcs_info:git:*' unstagedstr "${RED}+"
-zstyle ':vcs_info:*' formats "${GREEN}%c%u[%b]${RESET}"
-zstyle ':vcs_info:*' actionformats "${RED}%c%u[%b|%a]${RESET}"
-
-#-----------------------------------------------------------
-# Functions
-#-----------------------------------------------------------
-# get git branch status
-_update_vcs_info() {
-    LANG=en_US.UTF-8 vcs_info
-}
-add-zsh-hook precmd _update_vcs_info
-
-#-----------------------------------------------------------
 # Prompt
 #-----------------------------------------------------------
-PROMPT_CHAR=$'\u276f'
-PROMPT_DEFAULT=${BLUE}${PROMPT_CHAR}${RESET}
-PROMPT_ERROR=${RED}${PROMPT_CHAR}${RESET}
-PROMPT='
-%~ ${vcs_info_msg_0_}
-%(?.%{%G${PROMPT_DEFAULT}%}.%{%G${PROMPT_ERROR}%}) '
+# color
+zstyle :prompt:pure:path color gray
+zstyle :prompt:pure:prompt:success color 33
+zstyle :prompt:pure:prompt:error color 160


### PR DESCRIPTION
## なぜ
<!-- なぜPRを作成したのか -->
今まで自前でプロンプトの設定を用意していたが、プロンプトの管理コストを減らすために移行する。
シンプルで設定も複雑でない[Pure](https://github.com/sindresorhus/pure)に変更した。

## 変更点
<!-- PRでの変更点を記載する -->

- プロンプトをPureに変更
  - zinitにインストールする設定を追加
  - プロンプトの設定をpureの設定のみに変更
- init.vimのPython関連の設定を削除 (#17 の削除漏れ)

### 変更前

![image](https://user-images.githubusercontent.com/21972700/89746228-929ea500-daf3-11ea-8ffb-f7efaa15d468.png)

### 変更後

![image](https://user-images.githubusercontent.com/21972700/89746246-a813cf00-daf3-11ea-8f1c-1b1c12b86af2.png)
