### PR TITLE
k8s contexts の取得方法を `kube-ps1` に変更

### DIFF
--- a/config/zsh/01_zinit.zsh
+++ b/config/zsh/01_zinit.zsh
@@ -8,11 +8,14 @@ zinit light zsh-users/zsh-autosuggestions
 zinit light zsh-users/zsh-completions
 zinit light zdharma/fast-syntax-highlighting
 
-zinit ice from"gh-r" as"program"
-zinit load "junegunn/fzf-bin"
+zinit ice pick"kube-ps1.sh"
+zinit light "jonmosco/kube-ps1"
 
 zinit ice compile'(pure|async).zsh' pick'async.zsh' src'pure.zsh'
 zinit light sindresorhus/pure
+
+zinit ice from"gh-r" as"program"
+zinit load "junegunn/fzf-bin"
 
 zinit ice pick"bin/op-tool" as"program"
 zinit light m1yam0t0/op-tool

--- a/config/zsh/03_functions.zsh
+++ b/config/zsh/03_functions.zsh
@@ -76,31 +76,6 @@ _chpwd_ls() {
 }
 
 #-----------------------------------------------------------
-# Kubernetes
-#-----------------------------------------------------------
-
-# for iterm2
-_kube_get_context(){
-    KUBE_CONTEXT="$(kubectl config current-context 2> /dev/null)"
-}
-
-_kube_get_context_namespace(){
-    KUBE_NAMESPACE="$(kubectl config view --minify -o 'jsonpath={..namespace}')"
-    KUBE_NAMESPACE="|${KUBE_NAMESPACE:-default}"
-}
-
-_kube_context(){
-    local KUBE_SYMBOL=$'\u2638'
-    local KUBE_CONTEXT
-    local KUBE_NANESPACE
-
-    _kube_get_context
-    [ $? -eq 0 ]; _kube_get_context_namespace
-
-    echo ${KUBE_SYMBOL} ${KUBE_CONTEXT}${KUBE_NAMESPACE}
-}
-
-#-----------------------------------------------------------
 # Plugins
 #-----------------------------------------------------------
 ## adsf

--- a/config/zsh/07_prompt.zsh
+++ b/config/zsh/07_prompt.zsh
@@ -5,3 +5,15 @@
 zstyle :prompt:pure:path color gray
 zstyle :prompt:pure:prompt:success color 33
 zstyle :prompt:pure:prompt:error color 160
+
+# kube-ps1
+KUBE_PS1_PREFIX=''
+KUBE_PS1_SEPARATOR=''
+KUBE_PS1_DIVIDER='|'
+KUBE_PS1_SUFFIX=''
+KUBE_PS1_SYMBOL_COLOR=''
+KUBE_PS1_CTX_COLOR=''
+KUBE_PS1_NS_COLOR=''
+_KUBE_PS1_OPEN_ESC=''
+_KUBE_PS1_CLOSE_ESC=''
+_KUBE_PS1_DEFAULT_FG=''

--- a/config/zsh/08_iterm2.zsh
+++ b/config/zsh/08_iterm2.zsh
@@ -6,6 +6,6 @@ export ITERM2_SQUELCH_MARK=1
 
 # custom variable for iterm2 status bar
 iterm2_print_user_vars(){
-    iterm2_set_user_var kubeContext "$(_kube_context)"
+    iterm2_set_user_var kubeContext "$(kube_ps1)"
 }
 


### PR DESCRIPTION
## なぜ
<!-- なぜPRを作成したのか -->
iTerm で現在使用している k8s の context を表示するために自作関数を使っていた。
しかし、コマンド実行のたびに 1s 程度時間がかかってしまうため、`kube-ps1` に変更する

## 変更点
<!-- PRでの変更点を記載する -->

- config/zsh/01_zinit.zsh
  - `kube-ps1` をインストールするように設定追加
- config/zsh/03_functions.zsh
  - k8s context を取得するための自作関数を削除
- config/zsh/07_prompt.zsh
  - `kube-ps1` 関連の設定を追加
  - エスケープ文字が表示されてしまうため一部変数を無効化
- config/zsh/08_iterm2.zsh
  - k8s context の取得方法を `kube-ps1` に変更
