### PR TITLE
ZSHの起動を高速化

### DIFF
--- a/config/zsh/.zshenv
+++ b/config/zsh/.zshenv
@@ -8,3 +8,8 @@ export LANG=ja_JP.UTF-8
 export XDG_CONFIG_HOME=~/.config
 export XDG_CACHE_HOME=~/.cache
 export XDG_DATA_HOME=~/.local/share
+
+# asdf dirctory
+export ASDF_DIR="${XDG_CACHE_HOME}/asdf"
+export ASDF_DATA_DIR="${ASDF_DIR}"
+export ASDF_USER_SHIMS="${ASDF_DATA_DIR}/shims"

--- a/config/zsh/.zshrc
+++ b/config/zsh/.zshrc
@@ -1,5 +1,4 @@
 # asdf
-ASDF_DIR="${HOME}/.asdf"
 if [ -d "${ASDF_DIR}" ]; then
     source ${ASDF_DIR}/asdf.sh
     fpath=(${ASDF_DIR}/completions $fpath)

--- a/config/zsh/01_zinit.zsh
+++ b/config/zsh/01_zinit.zsh
@@ -1,5 +1,11 @@
+# set zinit environment variables
+typeset -A ZINIT
+ZINIT_HOME=$XDG_CACHE_HOME/zinit
+ZINIT[HOME_DIR]=$ZINIT_HOME
+ZINIT[ZCOMPDUMP_PATH]=$XDG_CACHE_HOME/zsh/zcompdump
+
 # init zinit
-source ${HOME}/.zinit/bin/zinit.zsh
+source ${ZINIT_HOME}/bin/zinit.zsh
 autoload -Uz _zinit
 (( ${+_comps} )) && _comps[zinit]=_zinit
 

--- a/config/zsh/01_zinit.zsh
+++ b/config/zsh/01_zinit.zsh
@@ -4,9 +4,13 @@ autoload -Uz _zinit
 (( ${+_comps} )) && _comps[zinit]=_zinit
 
 # load plugings
-zinit light "zsh-users/zsh-autosuggestions"
-zinit light "zsh-users/zsh-completions"
-zinit light "zdharma/fast-syntax-highlighting"
+zinit wait lucid for \
+ atinit"ZINIT[COMPINIT_OPTS]=-C; zicompinit; zicdreplay" \
+    zdharma/fast-syntax-highlighting \
+ atload"!_zsh_autosuggest_start" \
+    zsh-users/zsh-autosuggestions \
+ blockf \
+    zsh-users/zsh-completions
 
 zinit ice pick"kube-ps1.sh"
 zinit light jonmosco/kube-ps1

--- a/config/zsh/05_aliases.zsh
+++ b/config/zsh/05_aliases.zsh
@@ -48,7 +48,7 @@ alias vv='vi ${XDG_CONFIG_HOME}/nvim/init.vim'
 
 # shell
 alias reload='exec $SHELL -l'
-alias bench='time (zsh -i -c exit)'
+alias bench='for i in {1..10} ; do time ( zsh -i -c exit ); done'
 
 #-----------------------------------------------------------
 # global

--- a/config/zsh/06_options.zsh
+++ b/config/zsh/06_options.zsh
@@ -34,10 +34,6 @@ setopt hist_find_no_dups
 #-----------------------------------------------------------
 # Completion
 #-----------------------------------------------------------
-# Enable compinit
-autoload -Uz compinit
-compinit -d ${XDG_CACHE_HOME}/zsh/zcompdump
-
 zstyle ':completion:*' keep-prefix
 zstyle ':completion:*' matcher-list 'm:{a-z}={A-Z}'
 zstyle ':completion:*:default' menu select=2

--- a/etc/02_make-xdg-basedir.sh
+++ b/etc/02_make-xdg-basedir.sh
@@ -4,8 +4,8 @@
 source ${HOME}/.zshenv
 
 # list of directories
-CACHE_DIRS="zsh"
-DATA_DIRS="tig zsh"
+CACHE_DIRS=(zsh)
+DATA_DIRS=(tig zsh)
 
 # create cache directories
 for d in ${CACHE_DIRS}

--- a/etc/03_zinit.sh
+++ b/etc/03_zinit.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env zsh
 
-ZINIT_DIR="${HOME}/.zinit"
+# load environment variables from zshenv
+source ${HOME}/.zshenv
+
+ZINIT_DIR="${XDG_CACHE_HOME}/zinit"
 
 if [ ! -d ${ZINIT_DIR} ]; then
     mkdir ${ZINIT_DIR}

--- a/etc/04_asdf.sh
+++ b/etc/04_asdf.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env zsh
 
+# load environment variables from zshenv
+source ${HOME}/.zshenv
+
 # install asdf
-ASDF_DIR="${HOME}/.asdf"
 if [ ! -d "${ASDF_DIR}" ]; then
     git clone https://github.com/asdf-vm/asdf.git ${ASDF_DIR}
 fi
@@ -18,9 +20,6 @@ for p in ${ASDF_PLUGINS}
 do
     asdf plugin add $p
 done
-
-# Import the Node.js release team's OpenPGP keys to main keyring
-bash -c '${ASDF_DATA_DIR:=$HOME/.asdf}/plugins/nodejs/bin/import-release-team-keyring'
 
 # install each plugin
 asdf install


### PR DESCRIPTION
## なぜ
<!-- なぜPRを作成したのか -->

- zshの起動を高速化させるため

## 変更点
<!-- PRでの変更点を記載する -->

- 起動時間計測用コマンドで10回繰り返すように変更
- compinitの処理を `zicompinit` に統一
  - zcompdumpの出力先を `.cache/zsh/zcompdump` に変更
- zinitのプラグインの読み込みを遅延させるように修正
- `.asdf`, `.zinit` ディレクトリの格納先を変更
- `02_make-xdg-basedir.sh` で正しいディレクトリが作成できていない問題を修正

合計 80ms(0.08s) で起動できるように

```
~/.dotfiles tune-up-boot-shell*
❯ bench
( zsh -i -c exit; )  0.05s user 0.03s system 89% cpu 0.089 total
( zsh -i -c exit; )  0.05s user 0.03s system 97% cpu 0.080 total
( zsh -i -c exit; )  0.05s user 0.03s system 96% cpu 0.080 total
( zsh -i -c exit; )  0.05s user 0.03s system 95% cpu 0.080 total
( zsh -i -c exit; )  0.05s user 0.03s system 96% cpu 0.080 total
( zsh -i -c exit; )  0.05s user 0.03s system 96% cpu 0.080 total
( zsh -i -c exit; )  0.05s user 0.03s system 95% cpu 0.081 total
( zsh -i -c exit; )  0.05s user 0.03s system 95% cpu 0.080 total
( zsh -i -c exit; )  0.05s user 0.03s system 96% cpu 0.081 total
( zsh -i -c exit; )  0.05s user 0.03s system 96% cpu 0.080 total
```