### PR TITLE
スクリーンショット関連の設定を追加

### DIFF
--- a/.chezmoiscripts/arch/run_once_before_install-packages.sh.tmpl
+++ b/.chezmoiscripts/arch/run_once_before_install-packages.sh.tmpl
@@ -35,6 +35,7 @@ sudo pacman -S --noconfirm --needed \
     tmux \
     wezterm \
     vivaldi \
+    xclip \
     zsh
 
 # install packages via yay

--- a/dot_config/i3/config
+++ b/dot_config/i3/config
@@ -278,7 +278,10 @@ bindsym $mod+p exec /usr/local/bin/switch-audio-port
 ## App shortcuts
 bindsym $mod+w exec /usr/bin/vivaldi-stable
 bindsym $mod+n exec /usr/bin/thunar
-bindsym Print exec scrot ~/%Y-%m-%d-%T-screenshot.png && notify-send "Screenshot saved to ~/$(date +"%Y-%m-%d-%T")-screenshot.png"
+bindsym Print exec scrot ~/Desktop/%Y-%m-%d-%T-screenshot.png && notify-send "Screenshot saved to ~/Desktop/$(date +"%Y-%m-%d-%T")-screenshot.png"
+bindsym Ctrl+Print exec scrot /tmp/screenshot.png && xclip -selection clipboard -t image/png -i /tmp/screenshot.png && rm -f /tmp/screenshot.png && notify-send "Screenshot saved to clipboard"
+bindsym --release Shift+Print exec scrot -s ~/Desktop/%Y-%m-%d-%T-screenshot.png && notify-send "Screenshot saved to ~/Desktop/$(date +"%Y-%m-%d-%T")-screenshot.png"
+bindsym --release Ctrl+Shift+Print exec scrot -s /tmp/screenshot.png && xclip -selection clipboard -t image/png -i /tmp/screenshot.png && rm -f /tmp/screenshot.png && notify-send "Screenshot saved to clipboard"
 
 # Power Profiles menu switcher (rofi)
 bindsym $mod+Shift+p exec ~/.config/i3/scripts/power-profiles

--- a/dot_config/zsh/05_aliases.zsh
+++ b/dot_config/zsh/05_aliases.zsh
@@ -14,6 +14,7 @@ alias mkdir='mkdir -p'
 
 # replace command
 alias cat='bat -pp'
+alias imgcat='wezterm imgcat'
 alias ls='exa --color=always'
 alias tree='exa -T'
 alias vi='nvim'


### PR DESCRIPTION
## なぜ
<!-- なぜPRを作成したのか -->

- 範囲指定のスクリーンショット及び、クリップボードに保存することができるようにする。

## 変更点
<!-- PRでの変更点を記載する -->

- `.chezmoiscripts/arch/run_once_before_install-packages.sh.tmpl`
  - xclip をインストール対象に追加
- `dot_config/i3/config`
  - Screenshot 関連の keybind を追加
    - `Shift` キー同時押しで範囲選択
    - `Ctrl` キー同時押しでクリップボードに保存
- `dot_config/zsh/05_aliases.zsh`
  - `imgcat` のエイリアスを追加