### PR TITLE
git config でインデントがずれる問題を修正

### DIFF
--- a/dot_config/git/config.tmpl
+++ b/dot_config/git/config.tmpl
@@ -25,11 +25,13 @@
 [rebase]
     autosquash = true
     autostash = true
-{{- if env "GITHUB_ACTION" -}}
+{{- if not (env "GITHUB_ACTION") }}
 [url "git@github.com:"]
     insteadOf = https://github.com/
-{{- end -}}
+{{- end }}
 [delta]
+    navigate = true
+    light = false
     side-by-side = true
 [ghq]
     root = ~/src


### PR DESCRIPTION
## なぜ
<!-- なぜPRを作成したのか -->
Github Actions 以外の環境で git config のインデントがずれてしまい、git コマンドが使えないため

## 変更点
<!-- PRでの変更点を記載する -->
テンプレートで改行を詰めないように修正