### PR TITLE
Linux 以外で `.chezmoi.toml` のテンプレート出力に失敗しないように修正

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -1,5 +1,5 @@
 {{- $osBase := .chezmoi.os -}}
-{{- if hasKey .chezmoi.osRelease "idLike" -}}
+{{- if eq .chezmoi.os "linux" -}}
 {{-   $osBase = .chezmoi.osRelease.idLike -}}
 {{- end -}}
 

--- a/dot_config/zsh/01_plugins.zsh
+++ b/dot_config/zsh/01_plugins.zsh
@@ -21,9 +21,6 @@ zinit wait lucid for \
 zinit ice depth=1
 zinit light "romkatv/powerlevel10k"
 
-zinit ice pick"bin/op-tool" as"program"
-zinit light "m1yam0t0/op-tool"
-
 # if you already installed dircolors, load dircolors-solarized
 # dircolor file name
 DIRCOLOR_SOLARIZED_FILE='dircolors-solarized.zsh'


### PR DESCRIPTION
## なぜ
<!-- なぜPRを作成したのか -->

最新版の chezmoi で test job が失敗するようになっていたため
https://github.com/m1yam0t0/dotfiles/actions/runs/3256355584/jobs/5346712655
![image](https://user-images.githubusercontent.com/21972700/195998049-f498b30c-2ac2-434e-9405-51e5f919d367.png)

## 変更点
<!-- PRでの変更点を記載する -->

- fix: remove m1yam0t0/op-tool
- fix: Fix chezmoi.toml.tmpl if .chezmoi.osRelease is nil