### PR TITLE
Windows で動作しなかった部分を修正

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -10,7 +10,7 @@
 {{-   $private = true -}}
 {{- end -}}
 
-{{- if eq .chezmoi.hostname "mymt-thinkpad" -}}
+{{- if or (eq .chezmoi.hostname "mymt-desktop") (eq .chezmoi.hostname "mymt-thinkpad") -}}
 {{-   $private = true -}}
 {{- end -}}
 

--- a/.chezmoiscripts/windows/run_once_before_install-packages.ps1.tmpl
+++ b/.chezmoiscripts/windows/run_once_before_install-packages.ps1.tmpl
@@ -49,6 +49,7 @@ $wingetPackages =@(
     'Dropbox.Dropbox',
     'Google.JapaneseIME',
     'LINE.LINE',
+    'Microsoft.PowerToys',
     'Microsoft.VisualStudioCode',
     'Microsoft.WindowsTerminal',
     'Mozilla.Thunderbird',

--- a/Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1
+++ b/Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1
@@ -1,2 +1,3 @@
+$env:SHELL += "powershell.exe"
 $env:Path += ";$env:UserProfile\.local\bin"
 Set-Alias -Name g -Value git

--- a/dot_config/wezterm/wezterm.lua.tmpl
+++ b/dot_config/wezterm/wezterm.lua.tmpl
@@ -14,6 +14,6 @@ return {
   font_size = 12.0,
   color_scheme = 'Solarized Dark - Patched',
 {{- if eq .chezmoi.os "windows" }}
-  default_prog = { 'wsl.exe', '~', '-d', 'Ubuntu' }
+  default_prog = { 'wsl.exe', '~' }
 {{- end }}
 }


### PR DESCRIPTION
## なぜ
<!-- なぜPRを作成したのか -->

#123 での修正が足りない部分が判明したため

## 変更点
<!-- PRでの変更点を記載する -->

- PowerToys をインストールするように修正
- private と認識するために hostname を追加
  - windows の場合、`machine名\\user名` になることがわかったため
- WSL で開くときの distribution を設定しないように変更
  - デフォルトで設定されているものが開くようにするため
  - ubuntu, ubuntu-20.04 など微妙に違う場合があるため
- 環境変数に $SHELL を追加
  - Comspec に cmd.exe が設定されているために、`chezmoi cd`時にcmd.exeが起動してしまうため
  - https://github.com/twpayne/chezmoi/blob/9574f0a24b6851ad69d9925b0d0d7bc5029a1eed/pkg/shell/shell_windows.go#L8-L20
