### PR TITLE
SOPS でファイルを暗号・復号するための age key を追加

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -20,11 +20,14 @@ Documents
 .gitconfig
 {{ else }}
 .config/aquaproj-aqua
+.config/bat
 .config/gh
 .config/git
 .config/nvim
+.config/sops
 .config/zsh
 .gitconfig.local
+.local/share/zsh
 .zshenv
 {{ end }}
 
@@ -34,6 +37,10 @@ Documents
 .config/wezterm
 .xinitrc
 .xprofile
+{{ end }}
+
+{{ if not .private }}
+.config/sops
 {{ end }}
 
 {{ if env "GITHUB_ACTION" }}

--- a/dot_config/sops/age/private_keys.txt.tmpl
+++ b/dot_config/sops/age/private_keys.txt.tmpl
@@ -1,0 +1,1 @@
+{{ onepasswordRead "op://personal/sops-key/age.key" }}


### PR DESCRIPTION
## なぜ
<!-- なぜPRを作成したのか -->

SOPS で利用している age key を管理できるようにするため

## 変更点
<!-- PRでの変更点を記載する -->

- `.config/sops/age/keys.txt` を追加
  - 1password から取得するように
- private でない環境の場合、 age key を取得しないように `.chezmoiignore` を修正