### PR TITLE
fix: Disable phase updates on ubuntu (workaround)

### DIFF
--- a/.chezmoiscripts/debian/run_once_before_install-packages.sh.tmpl
+++ b/.chezmoiscripts/debian/run_once_before_install-packages.sh.tmpl
@@ -1,9 +1,9 @@
 {{ if eq .osbase "debian" -}}
 #!/usr/bin/env bash
 
-# disable phased updates
-# this is workaround. see below comment in issue.
+# NOTE: this is workaround. see below comment in issue.
 # https://github.com/actions/runner-images/issues/7192#issuecomment-1446766800
+# disable phased updates
 echo 'APT::Get::Always-Include-Phased-Updates "false";' | sudo tee /etc/apt/apt.conf.d/99-phased-updates
 
 # updgrade to latest packages

--- a/.chezmoiscripts/debian/run_once_before_install-packages.sh.tmpl
+++ b/.chezmoiscripts/debian/run_once_before_install-packages.sh.tmpl
@@ -1,6 +1,11 @@
 {{ if eq .osbase "debian" -}}
 #!/usr/bin/env bash
 
+# disable phased updates
+# this is workaround. see below comment in issue.
+# https://github.com/actions/runner-images/issues/7192#issuecomment-1446766800
+echo 'APT::Get::Always-Include-Phased-Updates "false";' | sudo tee /etc/apt/apt.conf.d/99-phased-updates
+
 # updgrade to latest packages
 sudo apt update
 sudo apt upgrade -y


### PR DESCRIPTION
## なぜ
<!-- なぜPRを作成したのか -->
`apt upgrade` を実行すると、grub-efi-amd64 のインストールに必ず失敗する。
これにより、PR Job が必ず失敗してしまう状態になっている。

phase update を有効にすることで、新しいパッケージが配布されてしまった結果、インストールに失敗しているかもしれないとのこと。
ワークアラウンドとして、phase update を無効化することで回避できるらしいので対処する。
https://github.com/actions/runner-images/issues/7192#issuecomment-1446766800

以下を apt 実行前に追記することで phase update を無効化することができる。

```sh
echo 'APT::Get::Always-Include-Phased-Updates "false";' | sudo tee /etc/apt/apt.conf.d/99-phased-updates
```

## 変更点
<!-- PRでの変更点を記載する -->

- Ubuntu でのパッケージインストール時に phase update を無効化するように修正（暫定）
