### PR TITLE
feat: Update wezterm config

### DIFF
--- a/dot_config/wezterm/wezterm.lua
+++ b/dot_config/wezterm/wezterm.lua
@@ -1,0 +1,46 @@
+local wezterm = require 'wezterm'
+local mux = wezterm.mux
+local config = {}
+
+wezterm.on('gui-startup', function(cmd)
+  local tab, pane, window = mux.spawn_window(cmd or {})
+  window:gui_window():maximize()
+end)
+
+wezterm.on('format-tab-title', function(tab, tabs, panes, config, hover, max_width)
+  local title = tab.tab_index + 1 .. ': ' .. tab.active_pane.title
+
+  return {
+    { Text = ' ' .. title .. ' ' },
+  }
+end)
+
+  config.window_decorations = 'INTEGRATED_BUTTONS|RESIZE'
+  config.color_scheme = 'nord'
+  config.font = wezterm.font 'MesloLGS NF'
+  config.font_size = 12.0
+
+if wezterm.target_triple == 'x86_64-pc-windows-msvc' then
+  config.default_prog = { 'wsl.exe', '~' }
+
+  config.launch_menu = {
+    {
+      label = 'Ubuntu(WSL)',
+      args = { 'wsl.exe', '~', '-d', 'Ubuntu' },
+    },
+    {
+      label = 'PowerShell',
+      args = { 'powershell.exe', '-NoLogo' },
+    },
+    {
+      label = 'Command Prompt',
+      args = { 'cmd.exe' },
+    },
+  }
+
+  config.keys = {
+    { key = 'l', mods = 'ALT', action = wezterm.action.ShowLauncherArgs { flags = 'FUZZY|LAUNCH_MENU_ITEMS' }},
+  }
+end
+
+return config

--- a/dot_config/wezterm/wezterm.lua.tmpl
+++ b/dot_config/wezterm/wezterm.lua.tmpl
@@ -1,19 +1,46 @@
 local wezterm = require 'wezterm'
-
-{{- if ne .chezmoi.os "linux" }}
 local mux = wezterm.mux
+local config = {}
 
-wezterm.on("gui-startup", function()
-  local tab, pane, window = mux.spawn_window{}
+wezterm.on('gui-startup', function(cmd)
+  local tab, pane, window = mux.spawn_window(cmd or {})
   window:gui_window():maximize()
 end)
-{{- end }}
 
-return {
-  font = wezterm.font 'MesloLGS NF',
-  font_size = 12.0,
-  color_scheme = 'nord',
-{{- if eq .chezmoi.os "windows" }}
-  default_prog = { 'wsl.exe', '~' }
-{{- end }}
-}
+wezterm.on('format-tab-title', function(tab, tabs, panes, config, hover, max_width)
+  local title = tab.tab_index + 1 .. ': ' .. tab.active_pane.title
+
+  return {
+    { Text = ' ' .. title .. ' ' },
+  }
+end)
+
+  config.window_decorations = 'INTEGRATED_BUTTONS|RESIZE'
+  config.color_scheme = 'nord'
+  config.font = wezterm.font 'MesloLGS NF'
+  config.font_size = 12.0
+
+if wezterm.target_triple == 'x86_64-pc-windows-msvc' then
+  config.default_prog = { 'wsl.exe', '~' }
+
+  config.launch_menu = {
+    {
+      label = 'Ubuntu(WSL)',
+      args = { 'wsl.exe', '~', '-d', 'Ubuntu' },
+    },
+    {
+      label = 'PowerShell',
+      args = { 'powershell.exe', '-NoLogo' },
+    },
+    {
+      label = 'Command Prompt',
+      args = { 'cmd.exe' },
+    },
+  }
+
+  config.keys = {
+    { key = 'l', mods = 'ALT', action = wezterm.action.ShowLauncherArgs { flags = 'FUZZY|LAUNCH_MENU_ITEMS' }},
+  }
+end
+
+return config


### PR DESCRIPTION
## なぜ
<!-- なぜPRを作成したのか -->

Wezterm の機能で、OSの種別を判別できるため、chezmoi のテンプレートを使う方式から変更する

[wezterm\.target\_triple \- Wez's Terminal Emulator](https://wezfurlong.org/wezterm/config/lua/wezterm/target_triple.html)

あわせて、Wezterm の一部設定を見直した

## 変更点
<!-- PRでの変更点を記載する -->

- `wezterm.target_triple` でOSごとに設定を変更するように修正
  - Windows の場合以下の設定を行うように変更
    - WSLを起動する設定
    - WSL/Powershell/コマンドプロンプトを起動する `launcher_menu` の追加
    - `Alt+l` で `launcher_menu` の起動
- window の表示形式を変更
  - タイトルバー非表示にして、ウィンドウの最小化・最大化・閉じるボタンをタブバーに表示させる
  - [window\_decorations \- Wez's Terminal Emulator](https://wezfurlong.org/wezterm/config/lua/config/window_decorations.html?h=window_decorations)