### PR TITLE
chezmoi を動かしている環境を特定できるように変数を変更

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -4,6 +4,8 @@
 {{- end -}}
 
 {{- $headless := false -}}
+{{- $wsl := false -}}
+{{- $github_actions := false -}}
 {{- $private := false -}}
 
 {{- if eq .chezmoi.username "m1yam0t0" -}}
@@ -14,8 +16,14 @@
 {{-   $private = true -}}
 {{- end -}}
 
-{{- if or (env "GITHUB_ACTION") (env "WSL_DISTRO_NAME") -}}
+{{- if (env "WSL_DISTRO_NAME") -}}
 {{-   $headless = true -}}
+{{-   $wsl = true -}}
+{{- end -}}
+
+{{- if (env "GITHUB_ACTION") -}}
+{{-   $headless = true -}}
+{{-   $github_actions = true -}}
 {{- end -}}
 
 {{- if or (env "SSH_CLIENT") (env "SSH_CONNECTION") -}}
@@ -25,4 +33,6 @@
 [data]
     osbase = {{ $osBase | quote }}
     headless = {{ $headless }}
+    wsl = {{ $wsl }}
+    github_actions = {{ $github_actions }}
     private = {{ $private }}

--- a/.chezmoiexternal.toml
+++ b/.chezmoiexternal.toml
@@ -36,7 +36,7 @@
     clone.args = ["--filter", "blob:none", "--branch", "stable"]
     pull.args = ["origin", "main"]
 
-{{ if env "WSL_DISTRO_NAME" -}}
+{{ if .wsl -}}
 [".local/bin/wsl2-ssh-agent"]
     type = "file"
     url = "https://github.com/mame/wsl2-ssh-agent/releases/latest/download/wsl2-ssh-agent"

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -41,6 +41,10 @@ Documents/**
 .config/zsh/.zprofile
 {{ end }}
 
+{{ if .github_actions }}
+.chezmoiscripts/windows/install-wsl.ps1
+{{ end }}
+
 {{ if not .private }}
 .config/sops/**
 .ssh/**

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -37,6 +37,10 @@ Documents/**
 .ssh/id_ed25519.pub
 {{ end }}
 
+{{ if not .wsl }}
+.config/zsh/.zprofile
+{{ end }}
+
 {{ if not .private }}
 .config/sops/**
 .ssh/**

--- a/.chezmoiscripts/windows/run_once_before_install-packages.ps1.tmpl
+++ b/.chezmoiscripts/windows/run_once_before_install-packages.ps1.tmpl
@@ -19,7 +19,7 @@ Write-Host 'Install packages via scoop'
 If (Get-Command scoop) {
     Write-Host 'scoop has already installed.'
 } else {
-{{- if env "GITHUB_ACTION" }}
+{{- if .github_actions }}
     iex "& {$(irm get.scoop.sh)} -RunAsAdmin"
 {{- else }}
     irm get.scoop.sh | iex


### PR DESCRIPTION
## なぜ
<!-- なぜPRを作成したのか -->

- chezmoi で利用する変数について、用途が増えてきた
  - 今まで OS を判別やデスクトップかどうかを判断するか使用していた
  - WSL で動いているか判断するケースが増えた(#486 で使用している [mame/wsl2-ssh-agent](https://github.com/mame/wsl2-ssh-agent) など)

## 変更点
<!-- PRでの変更点を記載する -->

- `.chezmoi.toml` で使う変数を追加
  - `wsl`, `github_actions` を追加
- 追加した変数をテンプレートで使用するように変更