### PR TITLE
Powershell 7.3 以降でも動作するように、Windows でのセットアップスクリプトを修正

### DIFF
--- a/.chezmoiscripts/windows/run_once_before_install-packages.ps1.tmpl
+++ b/.chezmoiscripts/windows/run_once_before_install-packages.ps1.tmpl
@@ -19,11 +19,7 @@ Write-Host 'Install packages via scoop'
 If (Get-Command scoop) {
     Write-Host 'scoop has already installed.'
 } else {
-{{- if .github_actions }}
-    iex "& {$(irm get.scoop.sh)} -RunAsAdmin"
-{{- else }}
-    irm get.scoop.sh | iex
-{{- end }}
+    $env:PSModulePath = ''; Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression
 }
 
 # Install Package via scoop

--- a/.github/workflows/check-installation.yml
+++ b/.github/workflows/check-installation.yml
@@ -22,11 +22,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set ExecutionPolicy
-        run: |
-          Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
+        run: Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
       - name: Install
-        run: |
-          '$params = "-b $HOME/.local/bin init --apply --branch ${{ github.ref_name }} m1yam0t0"', (irm https://get.chezmoi.io/ps1) | powershell -c -
+        run: iex "&{$(irm 'https://get.chezmoi.io/ps1')} -b $HOME/.local/bin -- init --apply --branch ${{ github.ref_name }} m1yam0t0"
       - name: Remove chezmoi binary
-        run: |
-          rm $HOME/.local/bin/chezmoi.exe -Force
+        run: rm $HOME/.local/bin/chezmoi.exe -Force


### PR DESCRIPTION
## なぜ
<!-- なぜPRを作成したのか -->

Windowsでのインストールチェックが通らなくなっていた。
https://github.com/m1yam0t0/dotfiles/actions/runs/8145860868/job/22263067616?pr=751

Windows Runner の Powershell が 7.3 になったことによって、色々動かなくなってしまったようなので、
インストールが通るように修正する。

## 変更点
<!-- PRでの変更点を記載する -->

- chezmoi のインストール時に実行しているコマンドを修正
- scoop インストール時に実行しているコマンドを修正
  - powershell 7.3 になったことで、scoop のインストールスクリプト内で実行している `Get-ExecutionPolicy` が実行できなくなってしまった。
    - Powershell 7 で、`PSModulePath` が変更された影響で、実行できなくなってしまっているケースがあるらしい
    - ワークアラウンドとして、`PSModulePath` の環境変数を空にすることで解消できるためその処理を追加
    - https://github.com/PowerShell/PowerShell/issues/18530
  - いつの間にか、`-RunAsAdmin` でなくても実行できるようになったのでオプションを変更
    - https://github.com/ScoopInstaller/Install/pull/77
