### PR TITLE
MinIO client(mc) をインストール

### DIFF
--- a/.chezmoiexternal.toml.tmpl
+++ b/.chezmoiexternal.toml.tmpl
@@ -41,5 +41,13 @@
     url = "https://github.com/mame/wsl2-ssh-agent/releases/latest/download/wsl2-ssh-agent"
     executable = true
     refreshPeriod = "168h"
-{{ end -}}
+{{- end }}
+
+{{ if .private -}}
+[".local/bin/mc"]
+    type = "file"
+    url = "https://dl.min.io/client/mc/release/{{ .chezmoi.os }}-{{ .chezmoi.arch }}/mc"
+    executable = true
+    refreshPeriod = "168h"
+{{- end }}
 {{- end -}}

--- a/.chezmoiignore.tmpl
+++ b/.chezmoiignore.tmpl
@@ -51,5 +51,6 @@ Documents/**
 .config/aquaproj-aqua/imports/private.yaml
 .config/mise/**
 .config/sops/**
+.mc/**
 .ssh/**
 {{ end }}

--- a/private_dot_mc/private_config.json.tmpl
+++ b/private_dot_mc/private_config.json.tmpl
@@ -1,0 +1,12 @@
+{
+    "version": "10",
+    "aliases": {
+        "infra": {
+            "url": "{{ onepasswordRead "op://personal/minio-infra/api/url" }}",
+            "accessKey": "{{ onepasswordRead "op://personal/minio-infra/personal_account/accesskey" }}",
+            "secretKey": "{{ onepasswordRead "op://personal/minio-infra/personal_account/secretkey" }}",
+            "api": "s3v4",
+            "path": "auto"
+        }
+    }
+}


### PR DESCRIPTION
## なぜ
<!-- なぜPRを作成したのか -->
自宅用の S3 bucket として [MinIO](https://min.io) を運用するようになったため、クライアントツールである `mc` をインストールしたい

## 変更点
<!-- PRでの変更点を記載する -->

- mc を利用するために必要なファイルを追加（私用端末のみ）
  - バイナリを `.chezmoi.external` でダウンロード
  - mc の設定ファイル
    - accesskey, secretkey は 1password から取得