### PR TITLE
Fix installation command

### DIFF
--- a/.chezmoiscripts/macos/run_once_before_install-packages.sh.tmpl
+++ b/.chezmoiscripts/macos/run_once_before_install-packages.sh.tmpl
@@ -19,7 +19,6 @@ fi
 
 # install packages via homebrew
 brew bundle --file=/dev/stdin <<EOF
-tap "homebrew/bundle"
 brew "coreutils"
 brew "git"
 brew "pinentry-mac"

--- a/.chezmoiscripts/macos/run_once_before_install-packages.sh.tmpl
+++ b/.chezmoiscripts/macos/run_once_before_install-packages.sh.tmpl
@@ -18,7 +18,7 @@ else
 fi
 
 # install packages via homebrew
-brew bundle --no-lock --file=/dev/stdin <<EOF
+brew bundle --file=/dev/stdin <<EOF
 tap "homebrew/bundle"
 brew "coreutils"
 brew "git"

--- a/.github/workflows/check-installation.yml
+++ b/.github/workflows/check-installation.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install
-        run: sh -c "$(curl -fsLS get.chezmoi.io)" -- -b ${HOME}/.local/bin init m1yam0t0 --apply --branch "${{ github.ref_name }}"
+        run: sh -c "$(curl -fsLS get.chezmoi.io/lb)" -- init m1yam0t0 --apply --branch "${{ github.ref_name }}"
       - name: Remove chezmoi binary
         run: rm -f ${HOME}/.local/bin/chezmoi
   install-windows:
@@ -24,6 +24,6 @@ jobs:
       - name: Set ExecutionPolicy
         run: Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
       - name: Install
-        run: iex "&{$(irm 'https://get.chezmoi.io/ps1')} -b $HOME/.local/bin -- init m1yam0t0 --apply --branch '${{ github.ref_name }}'"
+        run: iex "&{$(irm 'https://get.chezmoi.io/ps1')} -b $HOME/.local/bin -- init m1yam0t0 --apply --branch ${{ github.ref_name }}"
       - name: Remove chezmoi binary
         run: rm $HOME/.local/bin/chezmoi.exe -Force

--- a/.github/workflows/check-installation.yml
+++ b/.github/workflows/check-installation.yml
@@ -24,6 +24,6 @@ jobs:
       - name: Set ExecutionPolicy
         run: Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
       - name: Install
-        run: iex "&{$(irm 'https://get.chezmoi.io/ps1')} -b $HOME/.local/bin -- init m1yam0t0 --apply --branch ${{ github.ref_name }}"
+        run: iex "&{$(irm 'https://get.chezmoi.io/ps1')} -b $HOME/.local/bin -- init m1yam0t0 --apply --branch '${{ github.ref_name }}'"
       - name: Remove chezmoi binary
         run: rm $HOME/.local/bin/chezmoi.exe -Force

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ m1yam0t0's dotfiles. managed with [chezmoi](https://github.com/twpayne/chezmoi).
 ### MacOS, Ubuntu
 
 ```sh
-sh -c "$(curl -fsLS get.chezmoi.io)" -- -b ${HOME}/.local/bin init m1yam0t0 --apply
+sh -c "$(curl -fsLS get.chezmoi.io/lb)" -- init m1yam0t0 --apply
 rm -f ${HOME}/.local/bin/chezmoi
 ```
 
@@ -17,6 +17,6 @@ rm -f ${HOME}/.local/bin/chezmoi
 
 ```pwsh
 Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
-'$params = "-b $HOME/.local/bin init m1yam0t0 --apply"', (irm https://get.chezmoi.io/ps1) | powershell -c -
+iex "&{$(irm 'https://get.chezmoi.io/ps1')} -b $HOME/.local/bin -- init m1yam0t0 --apply"
 rm $HOME/.local/bin/chezmoi.exe
 ```


### PR DESCRIPTION
## なぜ
<!-- なぜPRを作成したのか -->
CI が失敗するようになったため修正
https://github.com/m1yam0t0/dotfiles/actions/runs/15081069701/job/42397649993?pr=1421

## 変更点
<!-- PRでの変更点を記載する -->
- Linux,MacOS のインストールコマンドを修正
- Windows のインストールコマンドを修正
- `brew bundle` の option から、`--no-lock` が非推奨になったため削除
- `homebrew/bundle` の tap が不要になったため削除

